### PR TITLE
fix(cli): remove typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub fn cli_init() -> Result<()> {
 
     match matches.subcommand() {
         ("scaffold", Some(subcmd)) => ScaffoldDescription::from_cli(subcmd)?.scaffold(),
-        _ => Err(anyhow!("cannot fin corresponding command")),
+        _ => Err(anyhow!("cannot find corresponding command")),
     }
 }
 


### PR DESCRIPTION
## 🐛 Bug Fixes

It seems that there is a typo in `src/lib.rs` file.

Replaced `fin` by `find`.

a025f3e - fix(cli): remove typo

Please let me know if it's looks good to you. Thank you!

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>