### PR TITLE
Add commands to template

### DIFF
--- a/.scaffold.toml
+++ b/.scaffold.toml
@@ -12,6 +12,16 @@ notes = """
 Have fun using this template called {{name}} ! Here is the description: {{description}} 
 """
 
+[hooks]
+# Commands to be executed before scaffolding, from within the generated project
+pre = [
+    "bash -c some_pre_script.sh"
+]
+# Commands to be executed after scaffolding, from within the generated project
+post = [
+    "cargo vendor",
+    "bash -c some_post_script.sh"
+]
 
 [parameters]
     # parameters.name is forbidden

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ handlebars_misc_helpers = "0.9.1"
 indicatif = "0.15.0"
 console = "0.12.0"
 globset = "0.4.5"
+shell-words = "1.0"
 
 [[bin]]
 path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ notes = """
 Have fun using this template called {{name}} ! Here is the description: {{description}}
 """
 
+[hooks]
+# Commands to be executed before scaffolding, from within the generated project
+pre = [
+    "bash -c some_pre_script.sh"
+]
+# Commands to be executed after scaffolding, from within the generated project
+post = [
+    "cargo vendor",
+    "bash -c some_post_script.sh"
+]
+
 # Parameters are basically all the variables needed to generate your template using templating.
 # It will be displayed as prompt to interact with user (thanks to the message subfield).
 # All the parameters will be available in your templates as variables (example: `{{description}}`).

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,9 +3,9 @@ use console::{Emoji, Style};
 use dialoguer::Password;
 use git2::{Cred, RemoteCallbacks, Repository};
 use std::env;
-use std::path::PathBuf;
+use std::path::Path;
 
-pub(crate) fn clone(repository: &str, target_dir: &PathBuf, passphrase_needed: bool) -> Result<()> {
+pub(crate) fn clone(repository: &str, target_dir: &Path, passphrase_needed: bool) -> Result<()> {
     let cyan = Style::new().cyan();
     println!(
         "{} {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@ use std::{
     env,
     fs::{self, File},
     io::Read,
-    path::PathBuf,
+    path::{Path, PathBuf},
+    process::Command,
     string::ToString,
 };
 
@@ -74,6 +75,7 @@ pub fn cli_init() -> Result<()> {
 pub struct ScaffoldDescription {
     template: TemplateDescription,
     parameters: Option<BTreeMap<String, Parameter>>,
+    hooks: Option<Hooks>,
     #[serde(skip)]
     target_dir: Option<PathBuf>,
     #[serde(skip)]
@@ -100,6 +102,12 @@ pub struct Parameter {
     r#type: ParameterType,
     default: Option<Value>,
     values: Option<Vec<Value>>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Hooks {
+    pre: Option<Vec<String>>,
+    post: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -328,6 +336,23 @@ impl ScaffoldDescription {
             Value::String(dir_path.to_str().unwrap_or_default().to_string()),
         );
 
+        // pre-hooks
+        if let Some(Hooks {
+            pre: Some(commands),
+            ..
+        }) = &self.hooks
+        {
+            if !commands.is_empty() {
+                let cyan = Style::new().cyan();
+                println!(
+                    "{} {}",
+                    Emoji("🤖", ""),
+                    cyan.apply_to("Triggering pre-hooks…"),
+                );
+                self.run_hooks(&dir_path, &commands)?;
+            }
+        }
+
         parameters.insert("name".to_string(), Value::String(name.clone()));
         // List entries inside directory
         let entries = WalkDir::new(&self.template_path)
@@ -425,6 +450,113 @@ impl ScaffoldDescription {
             );
         }
 
+        // post-hooks
+        if let Some(Hooks {
+            post: Some(commands),
+            ..
+        }) = &self.hooks
+        {
+            if !commands.is_empty() {
+                let cyan = Style::new().cyan();
+                println!(
+                    "{} {}",
+                    Emoji("🤖", ""),
+                    cyan.apply_to("Triggering post-hooks…"),
+                );
+                self.run_hooks(&dir_path, &commands)?;
+            }
+        }
+
         Ok(())
+    }
+
+    fn run_hooks(&self, project_path: &Path, commands: &[String]) -> Result<()> {
+        let initial_path = std::env::current_dir()?;
+        // move to project directory
+        std::env::set_current_dir(&project_path).map_err(|e| {
+            anyhow!(
+                "cannot change directory to project path {:?}: {}",
+                &project_path,
+                e
+            )
+        })?;
+        // run commands
+        let magenta = Style::new().magenta();
+        for cmd in commands {
+            println!("{} {}", Emoji("✨", ""), magenta.apply_to(cmd));
+            ScaffoldDescription::run_cmd(&cmd)?;
+        }
+        // move back to initial path
+        std::env::set_current_dir(&initial_path).map_err(|e| {
+            anyhow!(
+                "cannot move back to original path {:?}: {}",
+                &initial_path,
+                e
+            )
+        })?;
+        Ok(())
+    }
+
+    pub fn run_cmd(cmd: &str) -> Result<()> {
+        let mut command = ScaffoldDescription::setup_cmd(&cmd)?;
+        let mut child = command.spawn().expect("cannot execute command");
+        child.wait().expect("failed to wait on child process");
+        Ok(())
+    }
+
+    pub fn setup_cmd(cmd: &str) -> Result<Command> {
+        let splitted_cmd =
+            shell_words::split(&cmd).map_err(|e| anyhow!("cannot split command line : {}", e))?;
+        if splitted_cmd.is_empty() {
+            anyhow::bail!("command argument is invalid: empty after splitting");
+        }
+        let mut command = Command::new(&splitted_cmd[0]);
+        if splitted_cmd.len() > 1 {
+            command.args(&splitted_cmd[1..]);
+        }
+        Ok(command)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScaffoldDescription;
+    use std::fs::{remove_file, File};
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn split_and_run_cmd() {
+        let mut command = ScaffoldDescription::setup_cmd("ls -alh .").unwrap();
+        command.stdout(Stdio::null());
+        let mut child = command.spawn().expect("cannot execute command");
+        child.wait().expect("failed to wait on child process");
+
+        let mut command = ScaffoldDescription::setup_cmd("/bin/bash -c ls").unwrap();
+        command.stdout(Stdio::null());
+        let mut child = command.spawn().expect("cannot execute command");
+        child.wait().expect("failed to wait on child process");
+    }
+
+    #[test]
+    fn split_and_run_script() {
+        let script_name = "./test.sh";
+        let cmd = format!("/bin/bash -c {}", script_name);
+        {
+            let mut file = File::create(script_name).unwrap();
+            file.write_all(b"#!/bin/bash\nls .\nfree").unwrap();
+            Command::new("chmod")
+                .arg("+x")
+                .arg(&script_name)
+                .output()
+                .expect("can't set execute perm on script file");
+        }
+        let mut command = ScaffoldDescription::setup_cmd(&cmd).unwrap();
+        command.stdout(Stdio::null());
+        let mut child = command.spawn().expect("cannot execute command");
+        child.wait().expect("failed to wait on child process");
+        // uncomment to see output of script execution
+        // std::io::stdout().write_all(&_output.stdout).unwrap();
+        remove_file(&script_name).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ use globset::{Glob, GlobSetBuilder};
 use handlebars::Handlebars;
 use heck::KebabCase;
 use helpers::ForRangHelper;
-use indicatif::ProgressBar;
 use serde::{Deserialize, Serialize};
 use toml::Value;
 use walkdir::WalkDir;


### PR DESCRIPTION
This PR adds a list of commands in the template to be run after the scaffolding.

For example in our needs, we should call `cargo vendor` immediately after scaffolding our template.

These commands are run from within the generated project.