### PR TITLE
Only exclude `.scaffold.toml` if it is in root.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,7 +490,7 @@ impl ScaffoldDescription {
             } else {
                 let rendered_content = template_engine
                     .render_template(&content, &parameters)
-                    .map_err(|e| anyhow!("cannot render template : {}, {}", entry_path.to_str().unwrap_or_default(), e))?;
+                    .map_err(|e| anyhow!("cannot render template {entry_path:?} : {}", e))?;
                 let rendered_path = template_engine
                     .render_template(
                         dir_path
@@ -499,7 +499,7 @@ impl ScaffoldDescription {
                             .expect("path is not utf8 valid"),
                         &parameters,
                     )
-                    .map_err(|e| anyhow!("cannot render template for path : {}", e))?;
+                    .map_err(|e| anyhow!("cannot render template for path {entry_path:?} : {}", e))?;
 
                 (rendered_path, rendered_content)
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ impl ScaffoldDescription {
                     return false;
                 }
 
-                if entry.file_name() == SCAFFOLD_FILENAME {
+                if entry.depth() == 1 && entry.file_name() == SCAFFOLD_FILENAME {
                     return false;
                 }
 
@@ -490,7 +490,7 @@ impl ScaffoldDescription {
             } else {
                 let rendered_content = template_engine
                     .render_template(&content, &parameters)
-                    .map_err(|e| anyhow!("cannot render template : {}", e))?;
+                    .map_err(|e| anyhow!("cannot render template : {}, {}", entry_path.to_str().unwrap_or_default(), e))?;
                 let rendered_path = template_engine
                     .render_template(
                         dir_path


### PR DESCRIPTION
Only exclude `.scaffold.toml` if it is in root.
Add a path to template render error.