### PR TITLE
Update to use latest `git2` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dialoguer = "0.6.2"
 handlebars = "4.2"
 walkdir = "2.3.1"
 toml = "0.5.6"
-git2 = "0.14"
+git2 = "0.16"
 md5 = "0.7.0"
 handlebars_misc_helpers = { version = "0.12", default-features = false, features = ["string", "http_attohttpc", "json"], optional = true }
 indicatif = "0.15.0"


### PR DESCRIPTION
Most notably to introduce `git2@0.16.x` which potentially simplifies the
upgrade path for users who are impacted by [RUSTSEC-2023-0003].

As an alternative, users are also able to directly update their
`libgit2-sys` dependency, but this seems prudent to upgrade anyhow.

[RUSTSEC-2023-0003]: https://rustsec.org/advisories/RUSTSEC-2023-0003.html
