### PR TITLE
chore: enable 'vendored-openssl' feature for 'git2'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dialoguer = "0.6.2"
 handlebars = "4.2"
 walkdir = "2.3.1"
 toml = "0.5.6"
-git2 = "0.14"
+git2 = { version = "0.14", features = ["vendored-openssl"] }
 md5 = "0.7.0"
 handlebars_misc_helpers = { version = "0.12", default-features = false, features = ["string", "http_attohttpc", "json"], optional = true }
 indicatif = "0.15.0"


### PR DESCRIPTION
This PR enables the `vendored-openssl` crate for the `git2` dependency so that it is not necessary to have a valid install of OpenSSL to build this crate.

Please let me know if you think this should be behind a feature flag instead, my hunch is that enabling it by default is a better approach.