### PR TITLE
Use `auth-git2` crate for git authentication.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,14 @@ keywords = ["scaffold", "generate", "cargo", "templating"]
 
 [dependencies]
 anyhow = "1.0.32"
-clap = "2.33.3" 
+auth-git2 = "0.4.0"
+clap = "2.33.3"
 serde = { version = "1.0.115", features = ["derive"] }
 dialoguer = "0.6.2"
 handlebars = "4.2"
 walkdir = "2.3.1"
 toml = "0.5.6"
-git2 = { version = "0.16", features = ["vendored-openssl"] }
+git2 = { version = "0.17", features = ["vendored-openssl"] }
 md5 = "0.7.0"
 handlebars_misc_helpers = { version = "0.12", default-features = false, features = ["string", "http_attohttpc", "json"], optional = true }
 indicatif = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ name = "cargo-scaffold"
 [features]
 default = ["helpers"]
 helpers = ["handlebars_misc_helpers"]
+
+[dev-dependencies]
+tempfile = "3.7.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.66"

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 pub(crate) fn clone(
     repository: &str,
-    reference_opt: &Option<String>,
+    reference_opt: Option<&str>,
     target_dir: &Path,
     private_key_path: Option<&Path>,
 ) -> Result<()> {
@@ -74,23 +74,23 @@ mod tests {
     fn clone_http() {
         let template_path = "https://github.com/http-rs/surf.git";
         let tmp_dir = tempdir().unwrap();
-        clone(template_path, &None, tmp_dir.path(), None).unwrap();
+        clone(template_path, None, tmp_dir.path(), None).unwrap();
     }
 
     #[test]
     fn clone_http_commit() {
-        let commit = Some("8f0039488b3877ca59592900bc7ad645a83e2886".to_owned());
+        let commit = Some("8f0039488b3877ca59592900bc7ad645a83e2886");
         let template_path = "https://github.com/http-rs/surf.git";
         let tmp_dir = tempdir().unwrap();
-        clone(template_path, &commit, tmp_dir.path(), None).unwrap();
+        clone(template_path, commit, tmp_dir.path(), None).unwrap();
     }
 
     #[test]
     fn clone_http_branch() {
-        let branch = Some("main".to_owned());
+        let branch = Some("main");
         let template_path = "https://github.com/apollographql/router.git";
         let tmp_dir = tempdir().unwrap();
-        clone(template_path, &branch, tmp_dir.path(), None).unwrap();
+        clone(template_path, branch, tmp_dir.path(), None).unwrap();
     }
 
     #[test]
@@ -98,15 +98,15 @@ mod tests {
     fn clone_ssh() {
         let template_path = "git@github.com:http-rs/surf.git";
         let tmp_dir = tempdir().unwrap();
-        clone(template_path, &None, tmp_dir.path(), None).unwrap();
+        clone(template_path, None, tmp_dir.path(), None).unwrap();
     }
 
     #[test]
     // warn: your ssh key must be in pem format
     fn clone_ssh_commit() {
-        let commit = Some("8f0039488b3877ca59592900bc7ad645a83e2886".to_owned());
+        let commit = Some("8f0039488b3877ca59592900bc7ad645a83e2886");
         let template_path = "git@github.com:http-rs/surf.git";
         let tmp_dir = tempdir().unwrap();
-        clone(template_path, &commit, tmp_dir.path(), None).unwrap();
+        clone(template_path, commit, tmp_dir.path(), None).unwrap();
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -68,59 +68,37 @@ pub(crate) fn clone(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{env, fs};
+    use tempfile::tempdir;
 
     #[test]
     fn clone_http() {
         let template_path = "https://github.com/http-rs/surf.git";
-        let tmp_dir = env::temp_dir().join(format!("{:x}1", md5::compute(template_path)));
-        if tmp_dir.exists() {
-            fs::remove_dir_all(&tmp_dir).unwrap();
-        }
-        fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &None, &tmp_dir, None).unwrap();
-        fs::remove_dir_all(&tmp_dir).unwrap();
+        let tmp_dir = tempdir().unwrap();
+        clone(template_path, &None, tmp_dir.path(), None).unwrap();
     }
 
     #[test]
     fn clone_http_commit() {
         let commit = Some("8f0039488b3877ca59592900bc7ad645a83e2886".to_owned());
         let template_path = "https://github.com/http-rs/surf.git";
-        let tmp_dir =
-            env::temp_dir().join(format!("{:x}2", md5::compute(commit.clone().unwrap())));
-        if tmp_dir.exists() {
-            fs::remove_dir_all(&tmp_dir).unwrap();
-        }
-        fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &commit, &tmp_dir, None).unwrap();
-        fs::remove_dir_all(&tmp_dir).unwrap();
+        let tmp_dir = tempdir().unwrap();
+        clone(template_path, &commit, tmp_dir.path(), None).unwrap();
     }
 
     #[test]
     fn clone_http_branch() {
         let branch = Some("main".to_owned());
         let template_path = "https://github.com/apollographql/router.git";
-        let tmp_dir =
-            env::temp_dir().join(format!("{:x}2", md5::compute(branch.clone().unwrap())));
-        if tmp_dir.exists() {
-            fs::remove_dir_all(&tmp_dir).unwrap();
-        }
-        fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &branch, &tmp_dir, None).unwrap();
-        fs::remove_dir_all(&tmp_dir).unwrap();
+        let tmp_dir = tempdir().unwrap();
+        clone(template_path, &branch, tmp_dir.path(), None).unwrap();
     }
 
     #[test]
     // warn: your ssh key must be in pem format
     fn clone_ssh() {
         let template_path = "git@github.com:http-rs/surf.git";
-        let tmp_dir = env::temp_dir().join(format!("{:x}3", md5::compute(template_path)));
-        if tmp_dir.exists() {
-            fs::remove_dir_all(&tmp_dir).unwrap();
-        }
-        fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &None, &tmp_dir, None).unwrap();
-        fs::remove_dir_all(&tmp_dir).unwrap();
+        let tmp_dir = tempdir().unwrap();
+        clone(template_path, &None, tmp_dir.path(), None).unwrap();
     }
 
     #[test]
@@ -128,12 +106,7 @@ mod tests {
     fn clone_ssh_commit() {
         let commit = Some("8f0039488b3877ca59592900bc7ad645a83e2886".to_owned());
         let template_path = "git@github.com:http-rs/surf.git";
-        let tmp_dir = env::temp_dir().join(format!("{:x}4", md5::compute(commit.unwrap())));
-        if tmp_dir.exists() {
-            fs::remove_dir_all(&tmp_dir).unwrap();
-        }
-        fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &None, &tmp_dir, None).unwrap();
-        fs::remove_dir_all(&tmp_dir).unwrap();
+        let tmp_dir = tempdir().unwrap();
+        clone(template_path, &commit, tmp_dir.path(), None).unwrap();
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,15 +1,12 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use console::{Emoji, Style};
-use dialoguer::Password;
-use git2::{Cred, RemoteCallbacks};
 use std::path::Path;
 
 pub(crate) fn clone(
     repository: &str,
     reference_opt: &Option<String>,
     target_dir: &Path,
-    private_key_path: &Path,
-    passphrase_needed: bool,
+    private_key_path: Option<&Path>,
 ) -> Result<()> {
     let cyan = Style::new().cyan();
     println!(
@@ -17,30 +14,21 @@ pub(crate) fn clone(
         Emoji("🔄", ""),
         cyan.apply_to("Cloning repository…"),
     );
-    let mut fetch_options = git2::FetchOptions::new();
-    if !repository.starts_with("http") {
-        let mut callbacks = RemoteCallbacks::new();
-        let passphrase = if passphrase_needed {
-            Password::new()
-                .with_prompt(format!("Enter passphrase for {:?}", private_key_path))
-                .interact()?
-                .into()
-        } else {
-            None
-        };
-        callbacks.credentials(move |_url, username_from_url, _allowed_types| {
-            Cred::ssh_key(
-                username_from_url.unwrap(),
-                // Some(&private_key_path.with_extension("pub")),
-                None,
-                private_key_path,
-                passphrase.as_deref(),
-            )
-        });
 
-        // Prepare fetch options.
-        fetch_options.remote_callbacks(callbacks);
+    let mut auth = auth_git2::GitAuthenticator::default();
+    if let Some(private_key_path) = private_key_path {
+        auth = auth.add_ssh_key_from_file(private_key_path, None)
     }
+
+    let git_config = git2::Config::open_default()
+        .map_err(|e| anyhow!(e).context("Opening git configuration"))?;
+
+    let mut fetch_options = git2::FetchOptions::new();
+
+    // Add credentials callback.
+    let mut callbacks = git2::RemoteCallbacks::new();
+    callbacks.credentials(auth.credentials(&git_config));
+    fetch_options.remote_callbacks(callbacks);
 
     if reference_opt.is_some() {
         fetch_options.download_tags(git2::AutotagOption::All);
@@ -80,92 +68,72 @@ pub(crate) fn clone(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{env, fs, path::PathBuf};
+    use std::{env, fs};
 
     #[test]
     fn clone_http() {
-        let private_key_path = PathBuf::from(&format!(
-            "{}/.ssh/id_rsa",
-            env::var("HOME").expect("cannot fetch $HOME")
-        ));
         let template_path = "https://github.com/http-rs/surf.git";
-        let tmp_dir = env::temp_dir().join(format!("{:x}1", md5::compute(&template_path)));
+        let tmp_dir = env::temp_dir().join(format!("{:x}1", md5::compute(template_path)));
         if tmp_dir.exists() {
             fs::remove_dir_all(&tmp_dir).unwrap();
         }
         fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &None, &tmp_dir, &private_key_path, false).unwrap();
+        clone(template_path, &None, &tmp_dir, None).unwrap();
         fs::remove_dir_all(&tmp_dir).unwrap();
     }
 
     #[test]
     fn clone_http_commit() {
-        let private_key_path = PathBuf::from(&format!(
-            "{}/.ssh/id_rsa",
-            env::var("HOME").expect("cannot fetch $HOME")
-        ));
         let commit = Some("8f0039488b3877ca59592900bc7ad645a83e2886".to_owned());
         let template_path = "https://github.com/http-rs/surf.git";
         let tmp_dir =
-            env::temp_dir().join(format!("{:x}2", md5::compute(&commit.clone().unwrap())));
+            env::temp_dir().join(format!("{:x}2", md5::compute(commit.clone().unwrap())));
         if tmp_dir.exists() {
             fs::remove_dir_all(&tmp_dir).unwrap();
         }
         fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &commit, &tmp_dir, &private_key_path, false).unwrap();
+        clone(template_path, &commit, &tmp_dir, None).unwrap();
         fs::remove_dir_all(&tmp_dir).unwrap();
     }
 
     #[test]
     fn clone_http_branch() {
-        let private_key_path = PathBuf::from(&format!(
-            "{}/.ssh/id_rsa",
-            env::var("HOME").expect("cannot fetch $HOME")
-        ));
         let branch = Some("main".to_owned());
         let template_path = "https://github.com/apollographql/router.git";
         let tmp_dir =
-            env::temp_dir().join(format!("{:x}2", md5::compute(&branch.clone().unwrap())));
+            env::temp_dir().join(format!("{:x}2", md5::compute(branch.clone().unwrap())));
         if tmp_dir.exists() {
             fs::remove_dir_all(&tmp_dir).unwrap();
         }
         fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &branch, &tmp_dir, &private_key_path, false).unwrap();
+        clone(template_path, &branch, &tmp_dir, None).unwrap();
         fs::remove_dir_all(&tmp_dir).unwrap();
     }
 
     #[test]
     // warn: your ssh key must be in pem format
     fn clone_ssh() {
-        let private_key_path = PathBuf::from(&format!(
-            "{}/.ssh/id_rsa",
-            env::var("HOME").expect("cannot fetch $HOME")
-        ));
         let template_path = "git@github.com:http-rs/surf.git";
-        let tmp_dir = env::temp_dir().join(format!("{:x}3", md5::compute(&template_path)));
+        let tmp_dir = env::temp_dir().join(format!("{:x}3", md5::compute(template_path)));
         if tmp_dir.exists() {
             fs::remove_dir_all(&tmp_dir).unwrap();
         }
         fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &None, &tmp_dir, &private_key_path, false).unwrap();
+        clone(template_path, &None, &tmp_dir, None).unwrap();
         fs::remove_dir_all(&tmp_dir).unwrap();
     }
 
     #[test]
     // warn: your ssh key must be in pem format
     fn clone_ssh_commit() {
-        let private_key_path = PathBuf::from(&format!(
-            "{}/.ssh/id_rsa",
-            env::var("HOME").expect("cannot fetch $HOME")
-        ));
         let commit = Some("8f0039488b3877ca59592900bc7ad645a83e2886".to_owned());
         let template_path = "git@github.com:http-rs/surf.git";
-        let tmp_dir = env::temp_dir().join(format!("{:x}4", md5::compute(&commit.unwrap())));
+        let tmp_dir = env::temp_dir().join(format!("{:x}4", md5::compute(commit.unwrap())));
         if tmp_dir.exists() {
             fs::remove_dir_all(&tmp_dir).unwrap();
         }
         fs::create_dir_all(&tmp_dir).unwrap();
-        clone(template_path, &None, &tmp_dir, &private_key_path, false).unwrap();
+        clone(template_path, &None, &tmp_dir, None).unwrap();
         fs::remove_dir_all(&tmp_dir).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl ScaffoldDescription {
                 fs::create_dir_all(&tmp_dir)?;
                 git::clone(
                     &template_path,
-                    &opts.git_ref,
+                    opts.git_ref.as_deref(),
                     &tmp_dir,
                     opts.private_key_path.as_deref(),
                 )?;


### PR DESCRIPTION
The `auth-git2` crate supports more methods of authentication.

It supports: the ssh agent, the git credential helpers, more standard key locations in `$HOME/.ssh` (not just rsa), the askpass helper and falling back to prompting on the terminal. It can also detect encrypted OpenSSH keys by itself, so the user doesn't have to say `--passphrase-needed`.

Note that I'm also the author of the `auth-git2` crate. I wrote it last week to be able to use it here :)

Additionally, this PR changes path-name expansion to work per path component instead of on the whole path at once. This allows to remove the workaround with string replacement on windows, and it means windows and unix share the same implementation.

The PR also simplifies conversion of parameters to values as a preparation of more enhancements I have planned :)