### PR TITLE
Update buildstructor to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ console = "0.12.0"
 globset = "0.4.5"
 shell-words = "1.0"
 structopt = "0.3"
-buildstructor = "0.3.0"
+buildstructor = "0.5.4"
 
 [[bin]]
 path = "src/main.rs"


### PR DESCRIPTION
The version of buildstructor included is very old and has issues for people using asdf. Update to the latest version