### PR TITLE
Clap v4 and updating other dependencies (#43) 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,30 +3,28 @@ name = "cargo-scaffold"
 version = "0.8.14"
 authors = ["Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
 edition = "2021"
-description = "cargo scaffold lets you scaffold and generate an entire stack based on a simple toml file and make templating into your templates"
+description = "Scaffold and generate an entire stack using a simple toml config file and 'handlebars' templates."
 license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/iomentum/cargo-scaffold"
 keywords = ["scaffold", "generate", "cargo", "templating"]
 
 [dependencies]
-anyhow = "1.0.32"
-auth-git2 = "0.4.0"
-clap = "2.33.3"
-serde = { version = "1.0.115", features = ["derive"] }
-dialoguer = "0.6.2"
-handlebars = "4.2"
-walkdir = "2.3.1"
-toml = "0.5.6"
+anyhow = "1.0"
+auth-git2 = "0.5"
+clap = { version = "4.4", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
+dialoguer = "0.11"
+handlebars = "4.5"
+walkdir = "2.4"
+toml = "0.8"
 git2 = { version = "0.17", features = ["vendored-openssl"] }
-md5 = "0.7.0"
+md5 = "0.7"
 handlebars_misc_helpers = { version = "0.12", default-features = false, features = ["string", "http_attohttpc", "json"], optional = true }
-indicatif = "0.15.0"
-console = "0.12.0"
-globset = "0.4.5"
+indicatif = "0.17"
+console = "0.15"
+globset = "0.4"
 shell-words = "1.0"
-structopt = "0.3"
-buildstructor = "0.5.4"
 
 [[bin]]
 path = "src/main.rs"
@@ -37,4 +35,4 @@ default = ["helpers"]
 helpers = ["handlebars_misc_helpers"]
 
 [dev-dependencies]
-tempfile = "3.7.1"
+tempfile = "3.8"

--- a/examples/libusage.rs
+++ b/examples/libusage.rs
@@ -1,16 +1,17 @@
-use std::path::PathBuf;
-
 use anyhow::Result;
-use cargo_scaffold::{Opts, ScaffoldDescription};
+use clap::Parser;
 use toml::Value;
 
+use cargo_scaffold::{Opts, ScaffoldDescription};
 fn main() -> Result<()> {
-    let opts = Opts::builder()
-        .project_name(String::from("testlib"))
-        .template_path(PathBuf::from(
-            "https://github.com/Cosmian/mpc_rust_template.git",
-        ))
-        .build();
+    let args = vec![
+        "libusage",
+        "-n",
+        "testlib",
+        "https://github.com/Cosmian/mpc_rust_template.git",
+    ];
+    let opts = Opts::parse_from(args);
+
     // let mut params = BTreeMap::new();
     // params.insert("players_nb".to_string(), Value::Integer(3));
     let scaffold_desc = ScaffoldDescription::new(opts)?;

--- a/examples/libusage.rs
+++ b/examples/libusage.rs
@@ -1,22 +1,16 @@
 use anyhow::Result;
-use clap::Parser;
 use toml::Value;
 
 use cargo_scaffold::{Opts, ScaffoldDescription};
 fn main() -> Result<()> {
-    let args = vec![
-        "libusage",
-        "-n",
-        "testlib",
-        "https://github.com/Cosmian/mpc_rust_template.git",
-    ];
-    let opts = Opts::parse_from(args);
+    let opts = Opts::default()
+        .project_name("testlib")
+        .template_path("https://github.com/Cosmian/mpc_rust_template.git");
 
-    // let mut params = BTreeMap::new();
-    // params.insert("players_nb".to_string(), Value::Integer(3));
     let scaffold_desc = ScaffoldDescription::new(opts)?;
+
     let mut params = scaffold_desc.fetch_parameters_value()?;
     params.insert("players_nb".to_string(), Value::Integer(3));
+
     scaffold_desc.scaffold_with_parameters(params)
-    // .scaffold_with_parameters(params)
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.66"
+channel = "stable"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use clap::Parser;
 use console::{Emoji, Style};
 use dialoguer::{Confirm, Input, MultiSelect, Select};
 use fs::OpenOptions;
@@ -20,7 +21,6 @@ use globset::{Glob, GlobSetBuilder};
 use handlebars::Handlebars;
 use helpers::ForRangHelper;
 use serde::{Deserialize, Serialize};
-use structopt::StructOpt;
 use walkdir::WalkDir;
 
 pub use toml::Value;
@@ -81,85 +81,49 @@ pub enum ParameterType {
     MultiSelect,
 }
 
-#[derive(StructOpt)]
-pub enum Cargo {
-    #[structopt(about = "Scaffold a new project from a template")]
-    Scaffold(Opts),
-}
-
-#[derive(StructOpt)]
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about=None)]
 pub struct Opts {
     /// Specifiy your template location
-    #[structopt(name = "template", required = true)]
+    #[arg(name = "template", required = true)]
     pub template_path: PathBuf,
 
     /// Specifiy your template location in the repository if it's not located at the root of your repository
-    #[structopt(name = "repository_template_path", short = "r", long = "path")]
+    #[arg(name = "repository_template_path", short = 'r', long = "path")]
     pub repository_template_path: Option<PathBuf>,
 
     /// Full commit hash, tag or branch from which the template is cloned
     /// (i.e.: "deed14dcbf17ba87f6659ea05755cf94cb1464ab" or "v0.5.0" or "main")
-    #[structopt(name = "git_ref", short = "t", long = "git_ref")]
+    #[arg(name = "git_ref", short = 't', long = "git_ref")]
     pub git_ref: Option<String>,
 
     /// Specify the name of your generated project (and so skip the prompt asking for it)
-    #[structopt(name = "name", short = "n", long = "name")]
+    #[arg(name = "name", short = 'n', long = "name")]
     pub project_name: Option<String>,
 
     /// Specifiy the target directory
-    #[structopt(name = "target_directory", short = "d", long = "target_directory")]
+    #[arg(name = "target_directory", short = 'd', long = "target_directory")]
     pub target_dir: Option<PathBuf>,
 
     /// Override target directory if it exists
-    #[structopt(short = "f", long = "force")]
+    #[arg(short = 'f', long = "force")]
     pub force: bool,
 
     /// Append files in the target directory, create directory with the project name if it doesn't already exist but doesn't overwrite existing file (use force for that kind of usage)
-    #[structopt(short = "a", long = "append")]
+    #[arg(short = 'a', long = "append")]
     pub append: bool,
 
     /// Ignored, kept for backwards compatibility [DEPRECATED]
-    #[structopt(short = "p", long = "passphrase")]
+    #[arg(short = 'p', long = "passphrase")]
     pub passphrase_needed: bool,
 
     /// Specify if your private SSH key is located in another location than $HOME/.ssh/id_rsa
-    #[structopt(short = "k", long = "private_key_path")]
+    #[arg(short = 'k', long = "private_key_path")]
     pub private_key_path: Option<PathBuf>,
 
     /// Supply parameters via the command line in <name>=<value> format
-    #[structopt(long = "param")]
+    #[arg(long = "param")]
     pub parameters: Vec<String>,
-}
-
-#[buildstructor::buildstructor]
-impl Opts {
-    #[builder]
-    #[allow(clippy::too_many_arguments)]
-    #[allow(dead_code)]
-    pub fn new(
-        template_path: PathBuf,
-        repository_template_path: Option<PathBuf>,
-        git_ref: Option<String>,
-        project_name: Option<String>,
-        target_dir: Option<PathBuf>,
-        force: Option<bool>,
-        append: Option<bool>,
-        private_key_path: Option<PathBuf>,
-        parameters: Vec<String>,
-    ) -> Opts {
-        Self {
-            template_path,
-            repository_template_path,
-            git_ref,
-            project_name,
-            target_dir,
-            force: force.unwrap_or_default(),
-            append: append.unwrap_or_default(),
-            passphrase_needed: false,
-            private_key_path,
-            parameters,
-        }
-    }
 }
 
 impl ScaffoldDescription {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,32 +164,37 @@ pub struct Opts {
 }
 
 impl Opts {
+    /// Builder function for the `Opts` structure
+    pub fn builder<T: Into<PathBuf>>(template_path: T) -> Self {
+        Self::default().template_path(template_path)
+    }
+
     /// Set the template path for the structure.
-    pub fn template_path(mut self, path: &str) -> Self {
+    pub fn template_path<T: Into<PathBuf>>(mut self, path: T) -> Self {
         let _ = std::mem::replace(&mut self.template_path, path.into());
         self
     }
 
     /// Set the template path inside the repository
-    pub fn repository_template_path(mut self, path: &str) -> Self {
+    pub fn repository_template_path<T: Into<PathBuf>>(mut self, path: T) -> Self {
         let _ = self.repository_template_path.replace(path.into());
         self
     }
 
     /// Set the git reference
-    pub fn git_ref(mut self, gitref: &str) -> Self {
-        let _ = self.git_ref.replace(gitref.to_string());
+    pub fn git_ref<T: Into<String>>(mut self, gitref: T) -> Self {
+        let _ = self.git_ref.replace(gitref.into());
         self
     }
 
     /// Set the project name
-    pub fn project_name(mut self, name: &str) -> Self {
-        let _ = self.project_name.replace(name.to_string());
+    pub fn project_name<T: Into<String>>(mut self, name: T) -> Self {
+        let _ = self.project_name.replace(name.into());
         self
     }
 
     /// Set the target directory
-    pub fn target_dir(mut self, target_dir: &str) -> Self {
+    pub fn target_dir<T: Into<PathBuf>>(mut self, target_dir: T) -> Self {
         let _ = self.target_dir.replace(target_dir.into());
         self
     }
@@ -213,18 +218,18 @@ impl Opts {
     }
 
     /// Set the private key path
-    pub fn private_key_path(mut self, private_key_path: &str) -> Self {
+    pub fn private_key_path<T: Into<PathBuf>>(mut self, private_key_path: T) -> Self {
         let _ = self.private_key_path.replace(private_key_path.into());
         self
     }
 
-    /// Set the parameters (supplied as vec!["key1=value1", "key2=value2"]).
-    pub fn parameters(mut self, params: Vec<&str>) -> Self {
+    /// Set the parameters (supplied as `vec!["key1=value1", "key2=value2"]`).
+    pub fn parameters<T: Into<String>>(mut self, params: Vec<T>) -> Self {
         let _ = std::mem::replace(
             &mut self.parameters,
             params
-                .iter()
-                .map(|x| x.to_string())
+                .into_iter()
+                .map(|x| x.into())
                 .collect::<Vec<String>>(),
         );
         self
@@ -822,7 +827,11 @@ mod tests {
 
     #[test]
     fn test_build_opts_works() {
-        let opts = Opts::default();
+        let opts = Opts::builder("/path/to/template");
+        assert_eq!(
+            opts.template_path,
+            std::path::PathBuf::from("/path/to/template")
+        );
 
         // Test projct name can be set
         assert!(opts.project_name.is_none());
@@ -830,11 +839,14 @@ mod tests {
         assert_eq!(opts.project_name, Some("project".to_string()));
 
         // Test template can be set
-        assert_eq!(opts.template_path, std::path::PathBuf::from(""));
-        let opts = opts.template_path("/path/to/template");
         assert_eq!(
             opts.template_path,
             std::path::PathBuf::from("/path/to/template")
+        );
+        let opts = opts.template_path("/path/to/new-template");
+        assert_eq!(
+            opts.template_path,
+            std::path::PathBuf::from("/path/to/new-template")
         );
 
         // Test repository template path can be set.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
-use cargo_scaffold::{Cargo, ScaffoldDescription};
-use structopt::StructOpt;
+use clap::Parser;
+
+use cargo_scaffold::{Opts, ScaffoldDescription};
 
 fn main() -> Result<()> {
-    let Cargo::Scaffold(opts) = Cargo::from_args();
+    let opts = Opts::parse();
     ScaffoldDescription::new(opts)?.scaffold()
 }


### PR DESCRIPTION
Updated `clap` to `v4` and thus we can get rid of the unwanted `structopt` etc. 

Added documentation for generating scaffolding `Opts` structure and example usage.

Updated the 'libusage' example to use new `build` usage.

