### PR TITLE
only download the git tree at the commit we are targeting

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -34,6 +34,9 @@ pub(crate) fn clone(
         fetch_options.download_tags(git2::AutotagOption::All);
     }
 
+    // we don't need to download the entire history
+    fetch_options.depth(1);
+
     // Prepare builder.
     let mut builder = git2::build::RepoBuilder::new();
     builder.fetch_options(fetch_options);


### PR DESCRIPTION
Since we are only looking at the state of the tree, we don't need to clone the entire repository